### PR TITLE
使massCraft总能留下配方中物品

### DIFF
--- a/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
+++ b/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
@@ -189,8 +189,9 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler {
                     CraftingRecipe bookRecipe = InventoryUtils.getBookRecipeFromPattern(recipe);
                     if (bookRecipe != null && !bookRecipe.isIgnoredInRecipeBook()) { // Use recipe book if possible
                         // System.out.println("recipe");
-                        if(InventoryUtils.checkRecipeExist(recipe, gui)) {
-                            mc.interactionManager.clickRecipe(gui.getScreenHandler().syncId, bookRecipe, true);
+                        int option = InventoryUtils.checkRecipeEnough(recipe, gui);
+                        if(option > 0) {
+                            mc.interactionManager.clickRecipe(gui.getScreenHandler().syncId, bookRecipe, option > 1);
                         }
                     } else {
                         // System.out.println("move");

--- a/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
+++ b/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
@@ -189,7 +189,9 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler {
                     CraftingRecipe bookRecipe = InventoryUtils.getBookRecipeFromPattern(recipe);
                     if (bookRecipe != null && !bookRecipe.isIgnoredInRecipeBook()) { // Use recipe book if possible
                         // System.out.println("recipe");
-                        mc.interactionManager.clickRecipe(gui.getScreenHandler().syncId, bookRecipe, true);
+                        if(InventoryUtils.checkRecipeExist(recipe, gui)) {
+                            mc.interactionManager.clickRecipe(gui.getScreenHandler().syncId, bookRecipe, true);
+                        }
                     } else {
                         // System.out.println("move");
                         InventoryUtils.tryMoveItemsToFirstCraftingGrid(recipe, gui, true);

--- a/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
@@ -1495,35 +1495,42 @@ public class InventoryUtils {
         }
     }
 
-    public static boolean checkRecipeExist(RecipePattern recipe, HandledScreen<? extends ScreenHandler> gui) {
+    public static int checkRecipeEnough(RecipePattern recipe, HandledScreen<? extends ScreenHandler> gui) {
         Slot craftingOutputSlot = CraftingHandler.getFirstCraftingOutputSlotForGui(gui);
         ScreenHandler container = gui.getScreenHandler();
         int numSlots = container.slots.size();
         SlotRange range = CraftingHandler.getCraftingGridSlots(gui, craftingOutputSlot);
-        ItemStack[] recipeItems = recipe.getRecipeItems();
 
         // Check that the slot range is valid and that the recipe can fit into this type
         // of crafting grid
         if (range != null && range.getLast() < numSlots && recipe.getRecipeLength() <= range.getSlotCount()) {
             // This slot is used to check that we get items from a DIFFERENT inventory than
             // where this slot is in
+            Map<ItemType, IntArrayList> ingredientSlots = ItemType.getSlotsPerItem(recipe.getRecipeItems());
             Slot[] slotReference = {container.getSlot(range.getFirst()), craftingOutputSlot};
-            for(ItemStack stackReference : recipeItems) {
-                boolean isItemExist = false;
+            for(Map.Entry<ItemType, IntArrayList> entry : ingredientSlots.entrySet()) {
+                int count = 0;
+                int numSlotsWithItem = entry.getValue().size();
+                ItemStack stackReference = entry.getKey().getStack();
                 for(Slot slot : container.slots) {
-                    if(areSlotsInSameInventory(slot, slotReference) == false && slot.hasStack()
+                    if(!areSlotsInSameInventory(slot, slotReference) && slot.hasStack()
                             && areStacksEqual(stackReference, slot.getStack())){
-                        isItemExist = true;
-                        break;
+                        ++count;
+                        if(count > numSlotsWithItem) {
+                            break;
+                        }
                     }
                 }
-                if(!isItemExist) {
-                    return false;
+                if(count < numSlotsWithItem) {
+                    return 0;
+                }
+                else if (count == numSlotsWithItem) {
+                    return 1;
                 }
             }
-            return true;
+            return 2;
         }
-        return false;
+        return 0;
     }
 
     private static int putSingleItemIntoSlots(HandledScreen<? extends ScreenHandler> gui,

--- a/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
@@ -1495,6 +1495,37 @@ public class InventoryUtils {
         }
     }
 
+    public static boolean checkRecipeExist(RecipePattern recipe, HandledScreen<? extends ScreenHandler> gui) {
+        Slot craftingOutputSlot = CraftingHandler.getFirstCraftingOutputSlotForGui(gui);
+        ScreenHandler container = gui.getScreenHandler();
+        int numSlots = container.slots.size();
+        SlotRange range = CraftingHandler.getCraftingGridSlots(gui, craftingOutputSlot);
+        ItemStack[] recipeItems = recipe.getRecipeItems();
+
+        // Check that the slot range is valid and that the recipe can fit into this type
+        // of crafting grid
+        if (range != null && range.getLast() < numSlots && recipe.getRecipeLength() <= range.getSlotCount()) {
+            // This slot is used to check that we get items from a DIFFERENT inventory than
+            // where this slot is in
+            Slot[] slotReference = {container.getSlot(range.getFirst()), craftingOutputSlot};
+            for(ItemStack stackReference : recipeItems) {
+                boolean isItemExist = false;
+                for(Slot slot : container.slots) {
+                    if(areSlotsInSameInventory(slot, slotReference) == false && slot.hasStack()
+                            && areStacksEqual(stackReference, slot.getStack())){
+                        isItemExist = true;
+                        break;
+                    }
+                }
+                if(!isItemExist) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
     private static int putSingleItemIntoSlots(HandledScreen<? extends ScreenHandler> gui,
             IntArrayList targetSlots,
             int startIndex) {

--- a/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
@@ -1495,6 +1495,13 @@ public class InventoryUtils {
         }
     }
 
+    /**
+     * Check whether the player has enough items in their inventory
+     * to craft the given recipe even after an extra crafting step.
+     * For example, if the recipe requires 2 stone items, thus we cannot craft it with exactly 2 stone items left,
+     * as after the single crafting we could not pick up another stone item if the inventory is full.
+     * @param recipe The recipe to be crafted
+     */
     public static int checkRecipeEnough(RecipePattern recipe, HandledScreen<? extends ScreenHandler> gui) {
         Slot craftingOutputSlot = CraftingHandler.getFirstCraftingOutputSlotForGui(gui);
         ScreenHandler container = gui.getScreenHandler();
@@ -1509,23 +1516,18 @@ public class InventoryUtils {
             Map<ItemType, IntArrayList> ingredientSlots = ItemType.getSlotsPerItem(recipe.getRecipeItems());
             Slot[] slotReference = {container.getSlot(range.getFirst()), craftingOutputSlot};
             for(Map.Entry<ItemType, IntArrayList> entry : ingredientSlots.entrySet()) {
-                int count = 0;
                 int numSlotsWithItem = entry.getValue().size();
+                int countItems = 0, countSlots = 0;
                 ItemStack stackReference = entry.getKey().getStack();
                 for(Slot slot : container.slots) {
                     if(!areSlotsInSameInventory(slot, slotReference) && slot.hasStack()
                             && areStacksEqual(stackReference, slot.getStack())){
-                        ++count;
-                        if(count > numSlotsWithItem) {
-                            break;
-                        }
+                        countItems += slot.getStack().getCount();
+                        ++countSlots;
                     }
                 }
-                if(count < numSlotsWithItem) {
-                    return 0;
-                }
-                else if (count == numSlotsWithItem) {
-                    return 1;
+                if(countSlots <= numSlotsWithItem && countItems % numSlotsWithItem == 0) {
+                    return countItems == numSlotsWithItem ? 0 : 1;
                 }
             }
             return 2;

--- a/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
@@ -1516,17 +1516,17 @@ public class InventoryUtils {
             Map<ItemType, IntArrayList> ingredientSlots = ItemType.getSlotsPerItem(recipe.getRecipeItems());
             Slot[] slotReference = {container.getSlot(range.getFirst()), craftingOutputSlot};
             for(Map.Entry<ItemType, IntArrayList> entry : ingredientSlots.entrySet()) {
-                int numSlotsWithItem = entry.getValue().size();
-                int countItems = 0, countSlots = 0;
-                ItemStack stackReference = entry.getKey().getStack();
+                int countItems = 0;
+                final int numSlotsWithItem = entry.getValue().size();
+                final ItemStack stackReference = entry.getKey().getStack();
+                final int itemsCraftOnce = numSlotsWithItem * stackReference.getMaxCount();
                 for(Slot slot : container.slots) {
                     if(!areSlotsInSameInventory(slot, slotReference) && slot.hasStack()
                             && areStacksEqual(stackReference, slot.getStack())){
                         countItems += slot.getStack().getCount();
-                        ++countSlots;
                     }
                 }
-                if(countSlots <= numSlotsWithItem && countItems % numSlotsWithItem == 0) {
+                if(countItems <= itemsCraftOnce && countItems % numSlotsWithItem == 0) {
                     return countItems == numSlotsWithItem ? 0 : 1;
                 }
             }


### PR DESCRIPTION
## 描述
每次尝试合成前进行一次判断，判断本次合成后是否配方中的物品都会留下**至少一个格子**. 限于客户端配方书中的物品.

以活塞为例，一个活塞需要4个原石:
- 计算物品栏中有原石的物品总数
  - 若总数小于等于4则不合成，等于4的话格子就没了，小于的话合成也没用
  - 若总数不是4的倍数则用shift+配方书合成，多余的几个不会被放到工作台上
  - 若总数是4的倍数（且不是4）
    - 若总数大于4x64，也就是至少是一次shift+配方书合成的量加一，那么直接shift+配方书合成
    - 否则靠单次点击配方书降速合成