### PR TITLE
reservedCrafting模式开关与切石机合成完善

### DIFF
--- a/src/main/java/fi/dy/masa/itemscroller/config/Configs.java
+++ b/src/main/java/fi/dy/masa/itemscroller/config/Configs.java
@@ -65,6 +65,7 @@ public class Configs implements IConfigHandler
     public static class Toggles
     {
         public static final ConfigBoolean CRAFTING_FEATURES         = new ConfigBoolean("enableCraftingFeatures",           true, "Enables scrolling items to and from crafting grids,\nwith a built-in 18 recipe memory.\nHold down the Recipe key to see the stored recipes and\nto change the selection. While holding the Recipe key,\nyou can either scroll or press a number key to change the selection.\nA recipe is stored to the currently selected \"recipe slot\"\n by clicking pick block over a configured crafting output slot.\nThe supported crafting grids must be added to the scrollableCraftingGrids list.");
+        public static final ConfigBoolean RESERVED_CRAFTING          = new ConfigBoolean("enableReservedCrafting",          false, "Enables to reserve slots of items of recipes in inventory,\nso items on the ground could be picked up for further crafting");
         public static final ConfigBoolean DROP_MATCHING             = new ConfigBoolean("enableDropkeyDropMatching",        true, "Enables dropping all matching items from the same\ninventory with the hotkey");
         public static final ConfigBoolean RIGHT_CLICK_CRAFT_STACK   = new ConfigBoolean("enableRightClickCraftingOneStack", true, "Enables crafting up to one full stack when right clicking on\na slot that has been configured as a crafting output slot.");
         public static final ConfigBoolean SCROLL_EVERYTHING         = new ConfigBoolean("enableScrollingEverything",        true, "Enables scroll moving all items at once while\nholding the modifierMoveEverything keybind");
@@ -79,6 +80,7 @@ public class Configs implements IConfigHandler
 
         public static final ImmutableList<IConfigValue> OPTIONS = ImmutableList.of(
                 CRAFTING_FEATURES,
+                RESERVED_CRAFTING,
                 DROP_MATCHING,
                 RIGHT_CLICK_CRAFT_STACK,
                 SCROLL_EVERYTHING,

--- a/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
+++ b/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
@@ -193,9 +193,14 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler {
                     int stonecuttingRecipeIndex = InventoryUtils.getStonecuttingRecipeFromPattern(recipe);
                     if (!(gui instanceof StonecutterScreen) && bookRecipe != null && !bookRecipe.isIgnoredInRecipeBook()) { // Use recipe book if possible
                         // System.out.println("recipe");
-                        int option = InventoryUtils.checkRecipeEnough(recipe, gui);
-                        if(option > 0) {
-                            mc.interactionManager.clickRecipe(gui.getScreenHandler().syncId, bookRecipe, option > 1);
+                        if(Configs.Toggles.RESERVED_CRAFTING.getBooleanValue()) {
+                            int option = InventoryUtils.checkRecipeEnough(recipe, gui);
+                            if (option > 0) {
+                                mc.interactionManager.clickRecipe(gui.getScreenHandler().syncId, bookRecipe, option > 1);
+                            }
+                        }
+                        else{
+                            mc.interactionManager.clickRecipe(gui.getScreenHandler().syncId, bookRecipe, true);
                         }
                     }
                     else {

--- a/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
+++ b/src/main/java/fi/dy/masa/itemscroller/event/KeybindCallbacks.java
@@ -190,7 +190,6 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler {
                     RecipePattern recipe = RecipeStorage.getInstance().getSelectedRecipe();
 
                     CraftingRecipe bookRecipe = InventoryUtils.getBookRecipeFromPattern(recipe);
-                    int stonecuttingRecipeIndex = InventoryUtils.getStonecuttingRecipeFromPattern(recipe);
                     if (!(gui instanceof StonecutterScreen) && bookRecipe != null && !bookRecipe.isIgnoredInRecipeBook()) { // Use recipe book if possible
                         // System.out.println("recipe");
                         if(Configs.Toggles.RESERVED_CRAFTING.getBooleanValue()) {
@@ -205,6 +204,7 @@ public class KeybindCallbacks implements IHotkeyCallback, IClientTickHandler {
                     }
                     else {
                         InventoryUtils.tryMoveItemsToFirstCraftingGrid(recipe, gui, true);
+                        int stonecuttingRecipeIndex = InventoryUtils.getStonecuttingRecipeFromPattern(recipe);
                         if(stonecuttingRecipeIndex != -1 && gui instanceof StonecutterScreen) {
                             mc.interactionManager.clickButton((gui.getScreenHandler()).syncId, stonecuttingRecipeIndex);
                         }

--- a/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
+++ b/src/main/java/fi/dy/masa/itemscroller/util/InventoryUtils.java
@@ -1377,7 +1377,7 @@ public class InventoryUtils {
                 String cacheName = null;
                 for (int i = 0; i < 36; i++) {
                     CraftingRecipe bookRecipe = getBookRecipeFromPattern(recipe);
-                    if (bookRecipe != null && !bookRecipe.isIgnoredInRecipeBook()) { // Use recipe book if possible
+                    if (!(gui instanceof StonecutterScreen) && bookRecipe != null && !bookRecipe.isIgnoredInRecipeBook()) { // Use recipe book if possible
                         MinecraftClient mc = MinecraftClient.getInstance();
                         mc.interactionManager.clickRecipe(gui.getScreenHandler().syncId, bookRecipe, true);
                     } else {
@@ -1390,6 +1390,12 @@ public class InventoryUtils {
                         }
 
                         tryMoveItemsToCraftingGridSlots(recipe, slot, gui, true);
+
+                        int stonecuttingRecipeIndex = InventoryUtils.getStonecuttingRecipeFromPattern(recipe);
+                        if(stonecuttingRecipeIndex != -1 && gui instanceof StonecutterScreen) {
+                            MinecraftClient mc = MinecraftClient.getInstance();
+                            mc.interactionManager.clickButton((gui.getScreenHandler()).syncId, stonecuttingRecipeIndex);
+                        }
                     }
                     if(!StringUtils.isBlank(cacheName) && gui instanceof AnvilScreen) {
                         ((IMixinAnvilScreen)gui).itemscroller_setItemName(cacheName);


### PR DESCRIPTION
- 增加reservedCrafting模式的开关，默认关闭，即合成时保留一份配方物品以能从地上不断捡起物品.
- 切石机合成模式现在在craftEverything下也可用了，即合成但不扔出的模式.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>